### PR TITLE
Fix Incorrect Draw Order

### DIFF
--- a/entities/enemies/slime/scenes/slime.tscn
+++ b/entities/enemies/slime/scenes/slime.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=33 format=3 uid="uid://canu8q4nsyg2a"]
+[gd_scene load_steps=34 format=3 uid="uid://canu8q4nsyg2a"]
 
 [ext_resource type="Texture2D" uid="uid://mklv7yqx13jf" path="res://entities/enemies/slime/assets/slime.png" id="1_2mbw8"]
 [ext_resource type="Script" uid="uid://b6gjws1li2gd1" path="res://entities/scripts/entity.gd" id="1_6xq2y"]
@@ -14,6 +14,9 @@
 [ext_resource type="Texture2D" uid="uid://do15avt6sqajw" path="res://entities/assets/DestroySmoke.png" id="11_h77dj"]
 [ext_resource type="Script" uid="uid://bm84er77iesp0" path="res://entities/enemies/slime/scripts/enemy_state_stun.gd" id="11_jy1ul"]
 [ext_resource type="Script" uid="uid://8pe5nuwxntk1" path="res://entities/enemies/slime/scripts/enemy_state_destroy.gd" id="13_jy1ul"]
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_jy1ul"]
+radius = 13.0
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_umckf"]
 radius = 5.0
@@ -729,10 +732,11 @@ hit_box = NodePath("HitBox")
 state_machine = NodePath("EnemyStateMachine")
 
 [node name="HitBox" parent="." instance=ExtResource("3_v17ds")]
+position = Vector2(0, -5)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="HitBox"]
-rotation = 1.5707964
-shape = SubResource("CapsuleShape2D_umckf")
+position = Vector2(0, -7)
+shape = SubResource("CircleShape2D_jy1ul")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 position = Vector2(0, -19)
@@ -747,16 +751,19 @@ position = Vector2(0, 19)
 texture = ExtResource("1_ncw7u")
 
 [node name="HurtBox" parent="." instance=ExtResource("2_jy1ul")]
+position = Vector2(0, -5)
 collision_mask = 1
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="HurtBox"]
-rotation = 1.5707964
-shape = SubResource("CapsuleShape2D_umckf")
+position = Vector2(0, -7)
+shape = SubResource("CircleShape2D_jy1ul")
 
 [node name="HealthComponent" parent="." instance=ExtResource("2_co1cg")]
-max_health = 5.0
+position = Vector2(0, -5)
+_max_health = 5.0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(0, -5)
 rotation = 1.5707964
 shape = SubResource("CapsuleShape2D_umckf")
 
@@ -788,6 +795,7 @@ script = ExtResource("13_jy1ul")
 anim_name = "destroy"
 
 [node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="."]
+position = Vector2(0, -5)
 max_polyphony = 4
 
 [node name="DestroyEffectSprite" type="Sprite2D" parent="."]

--- a/entities/player/scenes/player.tscn
+++ b/entities/player/scenes/player.tscn
@@ -445,6 +445,7 @@ hit_box = NodePath("HitBox")
 state_machine = NodePath("StateMachine")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
+position = Vector2(0, -18)
 texture = ExtResource("2_cvnsp")
 hframes = 16
 vframes = 3
@@ -467,10 +468,11 @@ libraries = {
 autoplay = "no_attack"
 
 [node name="HealthComponent" parent="." instance=ExtResource("3_41mm0")]
+position = Vector2(0, -18)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 show_behind_parent = true
-position = Vector2(0, 20)
+position = Vector2(0, 2)
 shape = SubResource("CircleShape2D_ittr2")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
@@ -492,11 +494,13 @@ script = ExtResource("8_2suro")
 attack_sound = ExtResource("11_ekl84")
 
 [node name="Audio" type="Node2D" parent="."]
+position = Vector2(0, -18)
 
 [node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Audio"]
 max_polyphony = 4
 
 [node name="HitBox" parent="." instance=ExtResource("11_vwfor")]
+position = Vector2(0, -18)
 collision_layer = 1
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="HitBox"]
@@ -504,6 +508,7 @@ shape = SubResource("CapsuleShape2D_vgqql")
 
 [node name="Interactions" type="Node2D" parent="."]
 unique_name_in_owner = true
+position = Vector2(0, -18)
 
 [node name="HurtBox" parent="Interactions" instance=ExtResource("11_oucfp")]
 position = Vector2(0, 16)

--- a/game/scenes/game.tscn
+++ b/game/scenes/game.tscn
@@ -32,7 +32,8 @@ position = Vector2(426, 349)
 [node name="Plant5" parent="." instance=ExtResource("3_wowgv")]
 position = Vector2(338, 351)
 
-[node name="Enemies" type="Node" parent="."]
+[node name="Enemies" type="Node2D" parent="."]
+y_sort_enabled = true
 
 [node name="Slime" parent="Enemies" instance=ExtResource("3_ykdcs")]
 position = Vector2(1048, 330)
@@ -48,3 +49,6 @@ position = Vector2(720, 328)
 
 [node name="Slime5" parent="Enemies" instance=ExtResource("3_ykdcs")]
 position = Vector2(72, 88)
+
+[node name="Slime6" parent="Enemies" instance=ExtResource("3_ykdcs")]
+position = Vector2(381, 288)


### PR DESCRIPTION
Made sure that y-sort is enabled for the parent of all of the slime scenes, and that the player and slime sprites are just above the center of the position of their scene root nodes. Closes #40 