### PR TITLE
Fix Sprite Positions and Slime Health

### DIFF
--- a/components/health_component/health_component.gd
+++ b/components/health_component/health_component.gd
@@ -4,17 +4,17 @@ extends Node2D
 signal damaged
 signal destroyed
 
-@export var max_health: float = 100.0
-var health: float
+@export var _max_health: float = 100.0
+var _health: float
 
 
 func _ready():
-	health = max_health
+	_health = _max_health
 
 
 func damage(damage_taken: int) -> void:
-	health -= damage_taken
-	if health > 0:
+	_health -= damage_taken
+	if _health > 0:
 		damaged.emit()
 	else:
 		destroyed.emit()

--- a/entities/enemies/slime/scenes/slime.tscn
+++ b/entities/enemies/slime/scenes/slime.tscn
@@ -46,7 +46,7 @@ tracks/1/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [Vector2(0, -19)]
+"values": [Vector2(0, -24)]
 }
 tracks/2/type = "value"
 tracks/2/imported = false
@@ -86,7 +86,7 @@ tracks/1/keys = {
 "times": PackedFloat32Array(0, 0.1, 0.25, 0.3),
 "transitions": PackedFloat32Array(-2, 1, 1, 1),
 "update": 0,
-"values": [Vector2(0, -19), Vector2(0, -22), Vector2(0, -19), Vector2(0, -19)]
+"values": [Vector2(0, -24), Vector2(0, -27), Vector2(0, -24), Vector2(0, -24)]
 }
 tracks/2/type = "value"
 tracks/2/imported = false
@@ -166,7 +166,7 @@ tracks/1/keys = {
 "times": PackedFloat32Array(0, 0.1, 0.25, 0.3),
 "transitions": PackedFloat32Array(-2, 1, 1, 1),
 "update": 0,
-"values": [Vector2(0, -19), Vector2(0, -22), Vector2(0, -19), Vector2(0, -19)]
+"values": [Vector2(0, -24), Vector2(0, -27), Vector2(0, -24), Vector2(0, -24)]
 }
 tracks/2/type = "value"
 tracks/2/imported = false
@@ -246,7 +246,7 @@ tracks/1/keys = {
 "times": PackedFloat32Array(0, 0.1, 0.25, 0.3),
 "transitions": PackedFloat32Array(-2, 1, 1, 1),
 "update": 0,
-"values": [Vector2(0, -19), Vector2(0, -22), Vector2(0, -19), Vector2(0, -19)]
+"values": [Vector2(0, -24), Vector2(0, -27), Vector2(0, -24), Vector2(0, -24)]
 }
 tracks/2/type = "value"
 tracks/2/imported = false
@@ -327,7 +327,7 @@ tracks/1/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [Vector2(0, -19)]
+"values": [Vector2(0, -24)]
 }
 
 [sub_resource type="Animation" id="Animation_34c77"]
@@ -356,7 +356,7 @@ tracks/1/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [Vector2(0, -19)]
+"values": [Vector2(0, -24)]
 }
 
 [sub_resource type="Animation" id="Animation_fbeu0"]
@@ -385,7 +385,7 @@ tracks/1/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [Vector2(0, -19)]
+"values": [Vector2(0, -24)]
 }
 
 [sub_resource type="Animation" id="Animation_25h3e"]
@@ -414,7 +414,7 @@ tracks/1/keys = {
 "times": PackedFloat32Array(0, 0.1, 0.25, 0.3),
 "transitions": PackedFloat32Array(-2, 1, 1, 1),
 "update": 0,
-"values": [Vector2(0, -19), Vector2(0, -22), Vector2(0, -19), Vector2(0, -19)]
+"values": [Vector2(0, -24), Vector2(0, -27), Vector2(0, -24), Vector2(0, -24)]
 }
 tracks/2/type = "value"
 tracks/2/imported = false
@@ -470,7 +470,7 @@ tracks/1/keys = {
 "times": PackedFloat32Array(0, 0.1, 0.25, 0.3),
 "transitions": PackedFloat32Array(-2, 1, 1, 1),
 "update": 0,
-"values": [Vector2(0, -19), Vector2(0, -22), Vector2(0, -19), Vector2(0, -19)]
+"values": [Vector2(0, -24), Vector2(0, -27), Vector2(0, -24), Vector2(0, -24)]
 }
 tracks/2/type = "value"
 tracks/2/imported = false
@@ -526,7 +526,7 @@ tracks/1/keys = {
 "times": PackedFloat32Array(0, 0.1, 0.25, 0.3),
 "transitions": PackedFloat32Array(-2, 1, 1, 1),
 "update": 0,
-"values": [Vector2(0, -19), Vector2(0, -22), Vector2(0, -19), Vector2(0, -19)]
+"values": [Vector2(0, -24), Vector2(0, -27), Vector2(0, -24), Vector2(0, -24)]
 }
 tracks/2/type = "value"
 tracks/2/imported = false
@@ -582,7 +582,7 @@ tracks/1/keys = {
 "times": PackedFloat32Array(0, 0.2, 0.5, 0.7),
 "transitions": PackedFloat32Array(-2, -2, -2, -2),
 "update": 0,
-"values": [Vector2(0, -19), Vector2(0, -19), Vector2(0, -23), Vector2(0, -19)]
+"values": [Vector2(0, -24), Vector2(0, -24), Vector2(0, -28), Vector2(0, -24)]
 }
 
 [sub_resource type="Animation" id="Animation_nly76"]
@@ -611,7 +611,7 @@ tracks/1/keys = {
 "times": PackedFloat32Array(0, 0.2, 0.5, 0.7),
 "transitions": PackedFloat32Array(-2, -2, -2, -2),
 "update": 0,
-"values": [Vector2(0, -19), Vector2(0, -19), Vector2(0, -23), Vector2(0, -19)]
+"values": [Vector2(0, -24), Vector2(0, -24), Vector2(0, -28), Vector2(0, -24)]
 }
 
 [sub_resource type="Animation" id="Animation_8hb4w"]
@@ -640,7 +640,7 @@ tracks/1/keys = {
 "times": PackedFloat32Array(0, 0.2, 0.5, 0.7),
 "transitions": PackedFloat32Array(-2, -2, -2, -2),
 "update": 0,
-"values": [Vector2(0, -19), Vector2(0, -19), Vector2(0, -23), Vector2(0, -19)]
+"values": [Vector2(0, -24), Vector2(0, -24), Vector2(0, -28), Vector2(0, -24)]
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_6xq2y"]
@@ -739,7 +739,7 @@ position = Vector2(0, -7)
 shape = SubResource("CircleShape2D_jy1ul")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
-position = Vector2(0, -19)
+position = Vector2(0, -24)
 texture = ExtResource("1_2mbw8")
 hframes = 16
 vframes = 2

--- a/entities/player/scenes/player.tscn
+++ b/entities/player/scenes/player.tscn
@@ -445,7 +445,7 @@ hit_box = NodePath("HitBox")
 state_machine = NodePath("StateMachine")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
-position = Vector2(0, -18)
+position = Vector2(0, -23)
 texture = ExtResource("2_cvnsp")
 hframes = 16
 vframes = 3
@@ -468,11 +468,11 @@ libraries = {
 autoplay = "no_attack"
 
 [node name="HealthComponent" parent="." instance=ExtResource("3_41mm0")]
-position = Vector2(0, -18)
+position = Vector2(0, -23)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 show_behind_parent = true
-position = Vector2(0, 2)
+position = Vector2(0, -3)
 shape = SubResource("CircleShape2D_ittr2")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
@@ -494,13 +494,13 @@ script = ExtResource("8_2suro")
 attack_sound = ExtResource("11_ekl84")
 
 [node name="Audio" type="Node2D" parent="."]
-position = Vector2(0, -18)
+position = Vector2(0, -23)
 
 [node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Audio"]
 max_polyphony = 4
 
 [node name="HitBox" parent="." instance=ExtResource("11_vwfor")]
-position = Vector2(0, -18)
+position = Vector2(0, -23)
 collision_layer = 1
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="HitBox"]
@@ -508,7 +508,7 @@ shape = SubResource("CapsuleShape2D_vgqql")
 
 [node name="Interactions" type="Node2D" parent="."]
 unique_name_in_owner = true
-position = Vector2(0, -18)
+position = Vector2(0, -23)
 
 [node name="HurtBox" parent="Interactions" instance=ExtResource("11_oucfp")]
 position = Vector2(0, 16)


### PR DESCRIPTION
Player and Slime sprites have been moved up above their object positions, and the health component script has been updated so that max_health and health are now _max_health and _health (the Slime scene in the main branch still thought max_health was _max_health after it was renamed, so it's been changed back so it's max health should now be 5 again). Resolves #43 & closes #42 