### PR TITLE
Deactivate Slime's Hurt Box During its Death

### DIFF
--- a/entities/enemies/slime/scenes/slime.tscn
+++ b/entities/enemies/slime/scenes/slime.tscn
@@ -721,7 +721,7 @@ _data = {
 &"destroy": SubResource("Animation_2ipdc")
 }
 
-[node name="Slime" type="CharacterBody2D" unique_id=1513585146 node_paths=PackedStringArray("animation_player", "entity_sprite", "health_component", "hit_box", "state_machine")]
+[node name="Slime" type="CharacterBody2D" unique_id=1513585146 node_paths=PackedStringArray("animation_player", "entity_sprite", "health_component", "hit_box", "hurt_box", "state_machine")]
 collision_layer = 256
 collision_mask = 16
 script = ExtResource("1_6xq2y")
@@ -729,6 +729,7 @@ animation_player = NodePath("AnimationPlayer")
 entity_sprite = NodePath("Sprite2D")
 health_component = NodePath("HealthComponent")
 hit_box = NodePath("HitBox")
+hurt_box = NodePath("HurtBox")
 state_machine = NodePath("EnemyStateMachine")
 
 [node name="HitBox" parent="." unique_id=1135316748 instance=ExtResource("3_v17ds")]

--- a/entities/enemies/slime/scripts/enemy_state_destroy.gd
+++ b/entities/enemies/slime/scripts/enemy_state_destroy.gd
@@ -13,6 +13,7 @@ func init() -> void:
 
 func enter() -> void:
 	entity.is_invulnerable = true
+	entity.hurt_box.monitoring = false
 	_direction = entity.global_position.direction_to(_damage_position)
 	entity.direction = _direction
 	entity.velocity = _direction * -knockback_speed

--- a/entities/scripts/entity.gd
+++ b/entities/scripts/entity.gd
@@ -14,6 +14,7 @@ const DIR_4 = [Vector2.RIGHT, Vector2.DOWN, Vector2.LEFT, Vector2.UP]
 @export var entity_sprite: Sprite2D
 @export var health_component: HealthComponent
 @export var hit_box: HitBox
+@export var hurt_box: HurtBox
 @export var is_invulnerable: bool = false
 @export var state_machine: StateMachine
 


### PR DESCRIPTION
The slime's hurt box no longer monitors for bodies entering/exiting it after the slime is in the process of freeing itself. Fixes #57 